### PR TITLE
Add option to route emoji kitchen through a proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ apple_icons
 emoji-to-icon-filename.json
 node_modules
 package-lock.json
+pnpm-lock.yaml
+build-scripts/package.json
 icons
 wfbuild
 emoji-kitchen.bin

--- a/build-scripts/mkkitchen.sh
+++ b/build-scripts/mkkitchen.sh
@@ -6,4 +6,4 @@ cd emoji-kitchen
 npm install
 cd ..
 
-pkg --targets node12-macos-x64 ./emoji-kitchen --output emoji-kitchen.bin
+pkg --targets node14-macos-x64 ./emoji-kitchen --output emoji-kitchen.bin

--- a/emoji-kitchen/package.json
+++ b/emoji-kitchen/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "https-proxy-agent": "^7.0.6",
     "lookup-dns-cache": "^2.1.0"
   }
 }


### PR DESCRIPTION
Added support for environment variables. The variable is `FAMOS_PROXY`

![image](https://github.com/user-attachments/assets/b6d7c198-57ed-4924-a750-bbd740661fa5)
